### PR TITLE
Key/Account creation post-Genesis

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -9,6 +9,7 @@
 ## Guides
 * [Install Akash Suite](guides/install.md)
 * [Running a Local Testnet](guides/validators/local.md)
+* [Create Keys](guides/create-keys.md)
 
 ## Akashian
 * [The Challenge](akashian/README.md)

--- a/akashian/centauri-2.md
+++ b/akashian/centauri-2.md
@@ -57,9 +57,13 @@ The above configuraiton will sync your node with below set of seeds nodes and pe
 $ sudo service akashd start
 ```
 
+*Wait for the node to catch up with the Network's block height before attempting to use it for transactions.* View the current block hight via a network [explorer](https://akash.aneka.io/).
+
 5. Create validator
 
-Once the node has started, you should be able to use the same key from `centauri` to create a validator:
+If part of the first testnet, you should be able to use the same key from `centauri`. However if you're new to the network, you need to create a key to associate with the validator. See [account key creation](guides/create-keys.md) documentation to generate one and get initialized on the Network.
+
+Once the `akashd` node has started, create the validator:
 
 ```bash
 $ akashctl tx staking create-validator \

--- a/akashian/phase1.md
+++ b/akashian/phase1.md
@@ -15,11 +15,7 @@ export TEAM=<name>
 akashctl keys add $TEAM
 ```
 
-{% hint style='warning' %}
-
-Please store the menonic keys in a safe place
-
-{% endhint %}
+See [Creating Keys](guides/create-keys.md) documentation if joining after Genesis file has been finalized for steps.
 
 ### 2. Generate Genesis Transaction
 

--- a/guides/create-keys.md
+++ b/guides/create-keys.md
@@ -1,0 +1,33 @@
+Creating Keys
+-------------
+
+To interact with the Akash Network, an account key pair is needed to create and sign transactions. Akash uses the [Cosmos SDK Keyring](https://hub.cosmos.network/master/delegators/delegator-guide-cli.html#cosmos-accounts) toolchain to manage keys. The Cosmos SDK provides key management via a Ledger device, OS keyring, and files(for testing) are all supported and configured with the `akashctl... --keyring-backend` global flag. For more key management documentation see [Manage keys](usage/cli/keys.md).
+
+## Creating a Key Set
+
+Pick a memorable name, ideally team you've registered with for Akashian. Create a key locally using that name:
+
+```
+export TEAM=<name>
+akashctl keys add $TEAM
+```
+
+{% hint style='warning' %}
+
+Please store the menonic keys in a safe place
+
+{% endhint %}
+
+## Interacting with Akash Network
+
+To view the *address* of your created key:
+```sh
+akashctl keys show $TEAM -a
+<Address to request faucet funds>
+```
+
+Example address format: `akash1yg7y928farnqeggrduu7l4j427vez9j3uf40jp`
+
+**Note: To join the Akash Network after the Genesis file has been finalized, requires your key to be initialized on the chain by a transaction.**
+
+Join the [Akash Network](https://riot.im/app/#/room/#akashnet:matrix.org) Riot channel and request funds to be transfered to your *address* from an admin. Once the transaction is complete, you'll be able to interact with the Akash Network using that key!

--- a/usage/cli/send.md
+++ b/usage/cli/send.md
@@ -3,47 +3,61 @@
 > **Usage**
 
 ```text
-akashctl send <amount> <to-account> [flags]
+akashctl tx send [from_key_or_address] [to_address] [amount] [flags]
 ```
 
 > **Example**
 
-```text
-$ akashctl send 1.1 3d79b93370b8283d9b7399607efc29f589bba6f7 -k alpha
-
-Send Token(s)
-=============
-
-From:   	259d3831b178ef71545e992da9ea7b580032c9dd
-To:     	3d79b93370b8283d9b7399607efc29f589bba6f7
-Amount: 	1,100,000
-Block:  	1,498,809
-Hash:   	f01084f53fef96f1a8aebc5464ae49faa4c8a614a6e15542914bc1c55c0b4ed0
-
+```sh
+$ akashctl tx send akash180w6py0ke8f8su2u7zhvrrf57qt5s9dzhn7qzd akash1yg7y928farnqeggrduu7l4j427vez9j3uf40jp 10akash --memo "send monies" -y --fees 10akash --trace
+height: 0
+txhash: 2D3E80443E491B9246351229D543C66D9BE8815EF35B569DD6EBE187A7D0AF9D
+codespace: ""
+code: 0
+data: ""
+rawlog: '[]'
+logs: []
+info: ""
+gaswanted: 0
+gasused: 0
+tx: null
+timestamp: ""
 ```
 
-> In the example above, the amount is given in AKSH. You may also specify the amount in microAKSH \(AKSH \* 10^-6\) using the `u` unit suffix \(e.g. `100u` for 100 microAKSH\).
+> In the example above, the amount is given in AKASH. You may also specify the amount in microAKASH \(AKASH \* 10^-6\) using the `u` unit suffix \(e.g. `100u` for 100 microAKASH\).
 
-Use `akashctl send` to send tokens from one account to another.
+Use `akashctl tx send` to send tokens from one account to another.
 
 **Arguments**
 
 | Argument | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
-| amount | float | Y | The amount of tokens to send. |
+| from-accout | string | Y | The key addres of the senders account. |
 | to-account | string | Y | The key value for the recipient account. |
+| amount | float | Y | The amount of tokens to send. |
 
 **Flags**
 
 | Short | Verbose | Argument | Required | Description |
 | :--- | :--- | :--- | :--- | :--- |
-| -k | --key | string | Y | Name of one of your keys, for authentication. Tokens will be sent from this account. |
+|  | --dry-run | string | N | ignore the --gas flag and perform a simulation of a transaction, but don't broadcast it |
+|    | --fees | string | N | Fees to pay along with transaction; eg: 10uakash |
+|  | --gas | string | N | gas limit to set per-transaction; set to "auto" to calculate required gas automatically (default 200000) (default "200000") |
+|  | --gas-adjustment | float | N | adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1) |
+|  | --gas-prices | string | N | Gas prices to determine the transaction fee (e.g. 10uakt) |
+|  | --keyring-backend | string | N | Select keyring's backend (os|file|test) (default "os") |
+|  | --memo | string | N | Memo to send along with transaction |
 | -n | --node | string | N | Node host \(defaults to [https://api.akashtest.net:80](https://api.akashtest.net:80)\). |
 |  | --nonce | uint | N | Nonce. |
+| -y | --yes | bool | N | Skip tx broadcasting prompt confirmation |
+
 
 **Global Flags**
 
 | Short | Verbose | Argument | Required | Description |
 | :--- | :--- | :--- | :--- | :--- |
-| -d | --data | string | N | data directory (default "~/.akashctl") |
-| -m | --mode | string | N | output mode (interactive|shell|json) (default "interactive") |
+|  | --chain-id | string | N | Chain ID of tendermint node |
+| -e | --encoding | string | Binary encoding (hex|b64|btc) (default "hex") |
+|  | --home | string | N | data directory (default "~/.akashctl") |
+| -o | --output | string | N | Output format (text|json) (default "text") |
+|  | --trace | string | N | print out full stack trace on errors |


### PR DESCRIPTION
* Adding documentation of creating an account after the Genesis file was
created. Updated the `Phase 1` and `Centauri 2` documentation.
* Updated the `akashctl tx send` examples and configuration.
  * Not all of the flags were copied over from the `--help` output, only the ones I figured were most relevant.

No modification of documentation layout. 