### PR TITLE
Fixes to `guides/` Documentation

### DIFF
--- a/guides/deploy/README.md
+++ b/guides/deploy/README.md
@@ -80,7 +80,7 @@ pagination:
   total: "0"
 ```
 
-Please note the balance indicated is is denominated in uAKT (AKT x 10^-6), in the above example, the account has a balance of *93 AKT*. We're now setup to deploy.
+Please note the balance indicated is denominated in uAKT (AKT x 10^-6), in the above example, the account has a balance of *93 AKT*. We're now setup to deploy.
 
 {% hint style="warn" %}
 

--- a/guides/funding.md
+++ b/guides/funding.md
@@ -36,7 +36,7 @@ Go to the resulting URL and enter your account address; you should see tokens in
 
 **`mainnet`-only**
 
-Tokens may currently be purchased on echanges listed [here](https://akash.network/token). From there you can withdraw tokens to your address.
+Tokens may currently be purchased on exchanges listed [here](https://akash.network/token). From there you can withdraw tokens to your address.
 
 ### Check Balance
 


### PR DESCRIPTION
- fix typo in funding docs
- remove duplicate in deploy docs
- add trailing newline to deploy docs