### PR TITLE
remove duplicate akash command

### DIFF
--- a/guides/wallet.md
+++ b/guides/wallet.md
@@ -74,7 +74,7 @@ The command to recover your key is:
 ```bash
 akash \
   --keyring-backend "$AKASH_KEYRING_BACKEND" \
-  akash keys add "$AKASH_KEY_NAME" \
+  keys add "$AKASH_KEY_NAME" \
   --recover
 ```
 


### PR DESCRIPTION
The command has to be 
```
akash \
  --keyring-backend "$AKASH_KEYRING_BACKEND" \
  keys add "$AKASH_KEY_NAME" \
  --recover
```
Otherwise it's not working