### PR TITLE
Fixed Typo In Step 2: Create An Account

### DIFF
--- a/guides/deploy.md
+++ b/guides/deploy.md
@@ -104,7 +104,7 @@ export AKASH_ACCOUNT_ADDRESS="$(akash keys show $AKASH_KEY_NAME -a)"
 echo $AKASH_ACCOUNT_ADDRESS
 ```
 
-Note that if you close your Terminal window this variable will not bee saved. 
+Note that if you close your Terminal window this variable will not be saved. 
 
 ## Step 3. Fund your Account
 


### PR DESCRIPTION
Fixed a small typo I noticed when reading this page of the docs. The last sentence of "Step 2: Create An Account" read: "Note that if you close your Terminal window this variable will not bee saved." And I changed "bee" to "be".