### PR TITLE
update hrefs

### DIFF
--- a/stack-definition-language.md
+++ b/stack-definition-language.md
@@ -31,8 +31,8 @@ The top-level `services` entry contains a map of workloads to be ran on the Akas
 | `depends-on` | No | List of services which must be brought up before the current service |
 | `command` | No | Custom command use when executing container |
 | `args` | No | Arguments to custom command use when executing the container |
-| `env` | No | Environment variables to set in running container See [services.env](stack-definition-language.md#serviceenv) |
-| `expose` | No | Entities allowed to connect to to the services.  See [services.expose](stack-definition-language.md#servicesexpose). |
+| `env` | No | Environment variables to set in running container See [services.env](stack-definition-language.md#services-env) |
+| `expose` | No | Entities allowed to connect to to the services.  See [services.expose](stack-definition-language.md#services-expose). |
 
 ### services.env
 
@@ -54,7 +54,7 @@ env:
 | `as` | No | Port number to expose the container port as |
 | `accept` | No | List of hosts to accept connections for |
 | `proto` | No | Protocol type \(`tcp`,`http`, or `https`\) |
-| `to` | No | List of entities allowed to connect.  See [services.expose.to](stack-definition-language.md#servicesexposeto) |
+| `to` | No | List of entities allowed to connect.  See [services.expose.to](stack-definition-language.md#services-expose-to) |
 
 The `port` value governs the default `proto` value as follows:
 


### PR DESCRIPTION
The links are not working. 
At the bottom there are more but I do not know where they should link to as the according docs section seems to be not existing yet 
(ex: https://github.com/ovrclk/docs/blame/master/stack-definition-language.md#L165)